### PR TITLE
Fix Telemetry semantic type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,11 @@ The project follows a Feature Branch Workflow. So for each feature or bug a new 
 
 ## Testing
 Ensure that all new features added are tested and have unit tests for the same in the xUnit framework.
+
 # References
 This project is based on the Microsoft SDK recommendations outlined at 
 https://azure.github.io/azure-sdk/dotnet_introduction.html.
+
+The specifications for Digital Twins Definition Language version 2 (DTDLv2), are available 
+from Microsoft under a Creative Commons (Attribution) licence at:
+https://github.com/Azure/opendigitaltwins-dtdl

--- a/Telstra.Twins/Models/Content.cs
+++ b/Telstra.Twins/Models/Content.cs
@@ -3,11 +3,18 @@ using Newtonsoft.Json;
 
 namespace Telstra.Twins.Models
 {
-    public class Content
+    public abstract class Content
     {
+        protected Content(string baseType, string name = null, object schema = null)
+        {
+            BaseType = baseType;
+            Name = name;
+            Schema = schema;
+        }
+
         [System.Text.Json.Serialization.JsonIgnore]
         [Newtonsoft.Json.JsonIgnore]
-        public object BaseType { get; set; }
+        public string BaseType { get; set; }
 
         [JsonProperty("name", Order = -2)]
         [JsonPropertyName("name")]

--- a/Telstra.Twins/Models/Content.cs
+++ b/Telstra.Twins/Models/Content.cs
@@ -3,11 +3,11 @@ using Newtonsoft.Json;
 
 namespace Telstra.Twins.Models
 {
-    public partial class Content
+    public class Content
     {
-        [JsonProperty("@type", Order = -3)]
-        [JsonPropertyName("@type")]
-        public string Type { get; set; }
+        [System.Text.Json.Serialization.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        public object BaseType { get; set; }
 
         [JsonProperty("name", Order = -2)]
         [JsonPropertyName("name")]
@@ -16,5 +16,9 @@ namespace Telstra.Twins.Models
         [JsonProperty("schema", Order = -1)]
         [JsonPropertyName("schema")]
         public object Schema { get; set; }
+
+        [JsonProperty("@type", Order = -3)]
+        [JsonPropertyName("@type")]
+        public virtual object Type { get { return BaseType; } }
     }
 }

--- a/Telstra.Twins/Models/ModelComponent.cs
+++ b/Telstra.Twins/Models/ModelComponent.cs
@@ -4,7 +4,7 @@
     {
         public ModelComponent()
         {
-            this.Type = "Component";
+            this.BaseType = "Component";
         }
     }
 }

--- a/Telstra.Twins/Models/ModelComponent.cs
+++ b/Telstra.Twins/Models/ModelComponent.cs
@@ -1,10 +1,9 @@
 ﻿namespace Telstra.Twins.Models
 {
-    public partial class ModelComponent : Content
+    public partial class ModelComponent
     {
-        public ModelComponent()
+        public ModelComponent() : base("Component")
         {
-            this.BaseType = "Component";
         }
     }
 }

--- a/Telstra.Twins/Models/ModelProperty.Factory.cs
+++ b/Telstra.Twins/Models/ModelProperty.Factory.cs
@@ -7,7 +7,7 @@ using Telstra.Twins.Common;
 
 namespace Telstra.Twins.Models
 {
-    public partial class ModelProperty : Content
+    public partial class ModelProperty
     {
         public static ModelProperty Create(PropertyInfo info)
         {
@@ -22,7 +22,7 @@ namespace Telstra.Twins.Models
                 var attr = info.GetCustomAttribute<TwinTelemetryAttribute>();
                 if (attr != null)
                 {
-                    property.Type = "Telemetry";
+                    property.BaseType = "Telemetry";
                     property.SemanticType = attr.SemanticType;
                     property.Unit = attr.Unit;
                 };

--- a/Telstra.Twins/Models/ModelProperty.cs
+++ b/Telstra.Twins/Models/ModelProperty.cs
@@ -1,16 +1,36 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 using Telstra.Twins.Serialization;
 
 namespace Telstra.Twins.Models
 {
     public partial class ModelProperty : Content
     {
-        public string SemanticType { get; set; }
         public string DisplayName { get; set; }
         public string Description { get; set; }
         public string Id { get; set; }
         public string Comment { get; set; }
+
+        [System.Text.Json.Serialization.JsonIgnore]
+        [Newtonsoft.Json.JsonIgnore]
+        public string SemanticType { get; set; }
+
+        [JsonProperty("@type", Order = -3)]
+        [JsonPropertyName("@type")]
+        public override object Type
+        {
+            get
+            {
+                if (string.IsNullOrWhiteSpace(SemanticType))
+                    return BaseType;
+                return new[] { BaseType, SemanticType };
+            }
+        }
+
+        [JsonProperty("unit")]
+        [JsonPropertyName("unit")]
         public string Unit { get; set; }
+
         public bool? Writable { get; set; }
 
         public ModelProperty(string name,
@@ -36,7 +56,7 @@ namespace Telstra.Twins.Models
 
         public ModelProperty()
         {
-            this.Type = "Property";
+            this.BaseType = "Property";
         }
     }
 }

--- a/Telstra.Twins/Models/ModelProperty.cs
+++ b/Telstra.Twins/Models/ModelProperty.cs
@@ -6,10 +6,10 @@ namespace Telstra.Twins.Models
 {
     public partial class ModelProperty : Content
     {
-        public string DisplayName { get; set; }
-        public string Description { get; set; }
-        public string Id { get; set; }
         public string Comment { get; set; }
+        public string Description { get; set; }
+        public string DisplayName { get; set; }
+        public string Id { get; set; }
 
         [System.Text.Json.Serialization.JsonIgnore]
         [Newtonsoft.Json.JsonIgnore]
@@ -41,7 +41,7 @@ namespace Telstra.Twins.Models
             string id = null,
             string comment = null,
             string unit = null,
-            bool? writable = null) : this()
+            bool? writable = null) : base("Property")
         {
             this.SemanticType = semanticType;
             this.DisplayName = displayName;
@@ -54,9 +54,8 @@ namespace Telstra.Twins.Models
             this.Schema = schema;
         }
 
-        public ModelProperty()
+        public ModelProperty(): base("Property")
         {
-            this.BaseType = "Property";
         }
     }
 }

--- a/Telstra.Twins/Models/ModelRelationship.cs
+++ b/Telstra.Twins/Models/ModelRelationship.cs
@@ -13,9 +13,8 @@ namespace Telstra.Twins.Models
             int? maxMultiplicity = null,
             int? minMultiplicity = null,
             string target = null,
-            bool? writable = null)
+            bool? writable = null) : base("Relationship")
         {
-            BaseType = "Relationship";
             Name = name;
             DisplayName = displayName;
             Id = id;

--- a/Telstra.Twins/Models/ModelRelationship.cs
+++ b/Telstra.Twins/Models/ModelRelationship.cs
@@ -15,7 +15,7 @@ namespace Telstra.Twins.Models
             string target = null,
             bool? writable = null)
         {
-            Type = "Relationship";
+            BaseType = "Relationship";
             Name = name;
             DisplayName = displayName;
             Id = id;

--- a/Tests/Telstra.Twins.Test/TwinTelemetryAttributeTests.cs
+++ b/Tests/Telstra.Twins.Test/TwinTelemetryAttributeTests.cs
@@ -1,0 +1,40 @@
+﻿using Telstra.Twins.Attributes;
+using Telstra.Twins.Core;
+using Telstra.Twins.Services;
+using Xunit;
+
+namespace Telstra.Twins.Test
+{
+    public class TwinTelemetryAttributeTests
+    {
+        public TwinTelemetryAttributeTests()
+        {
+            var modelLibrary = new ModelLibrary();
+            Serializer = new DigitalTwinSerializer(modelLibrary);
+        }
+
+        private DigitalTwinSerializer Serializer { get; }
+
+        [Fact]
+        public void BasicTelemetryShouldSerialiseToModel()
+        {
+            var expectedModel = @"{
+""@id"": ""dtmi:telstra:twins:test:twinwithtelemetry;1"",
+""@type"": ""Interface"",
+""@context"": ""dtmi:dtdl:context;2"",
+""contents"": [
+    {  ""@type"": ""Telemetry"", ""name"": ""measurement"", ""schema"": ""integer"" }
+]}";
+
+            var model = Serializer.SerializeModel(typeof(TwinWithTelemetry));
+
+            JsonAssert.Equal(expectedModel, model);
+        }
+
+        [DigitalTwin]
+        private class TwinWithTelemetry : TwinBase
+        {
+            [TwinTelemetry] public int Measurement { get; set; }
+        }
+    }
+}

--- a/Tests/Telstra.Twins.Test/TwinTelemetryAttributeTests.cs
+++ b/Tests/Telstra.Twins.Test/TwinTelemetryAttributeTests.cs
@@ -19,20 +19,49 @@ namespace Telstra.Twins.Test
         public void BasicTelemetryShouldSerialiseToModel()
         {
             var expectedModel = @"{
-""@id"": ""dtmi:telstra:twins:test:twinwithtelemetry;1"",
+""@id"": ""dtmi:telstra:twins:test:telemetrytwin;1"",
 ""@type"": ""Interface"",
 ""@context"": ""dtmi:dtdl:context;2"",
 ""contents"": [
     {  ""@type"": ""Telemetry"", ""name"": ""measurement"", ""schema"": ""integer"" }
 ]}";
 
-            var model = Serializer.SerializeModel(typeof(TwinWithTelemetry));
+            var model = Serializer.SerializeModel(typeof(TelemetryTwin));
+
+            JsonAssert.Equal(expectedModel, model);
+        }
+
+
+        [Fact]
+        public void SemanticTelemetryShouldSerialiseToModel()
+        {
+            var expectedModel = @"{
+""@id"": ""dtmi:telstra:twins:test:semantictelemetrytwin;1"",
+""@type"": ""Interface"",
+""@context"": ""dtmi:dtdl:context;2"",
+""contents"": [
+    {  
+        ""@type"": [""Telemetry"", ""Temperature""], 
+        ""name"": ""measurement"", 
+        ""schema"": ""integer"", 
+        ""unit"": ""degreeCelsius"" 
+    }
+]}";
+
+            var model = Serializer.SerializeModel(typeof(SemanticTelemetryTwin));
 
             JsonAssert.Equal(expectedModel, model);
         }
 
         [DigitalTwin]
-        private class TwinWithTelemetry : TwinBase
+        private class SemanticTelemetryTwin : TwinBase
+        {
+            [TwinTelemetry(SemanticType = "Temperature", Unit = "degreeCelsius")]
+            public int Measurement { get; set; }
+        }
+
+        [DigitalTwin]
+        private class TelemetryTwin : TwinBase
         {
             [TwinTelemetry] public int Measurement { get; set; }
         }


### PR DESCRIPTION
First fix for semantic type support for #8 , this fixes the existing Telemetry property type.

* Separate out the BaseType from the Type/@type that is serialised for DTDLv2 (and hide BaseType from JSON)
* Where SemanticType is specified, include both BaseType and SemanticType.
* Hide the SemanticType property from JSON
* Correct naming for the Units property

Also includes unit tests for the relevant model serialisation. (Tests were written first, and checked in as a separate commit, for ease of review).

(Issue can remain open, as we still need to apply the same to Property attributes, and also define the types/units)